### PR TITLE
Modificación en la plantilla 'edita.html' y nueva prueba 'test_edita_editor'

### DIFF
--- a/colabora/templates/edita.html
+++ b/colabora/templates/edita.html
@@ -8,7 +8,9 @@
 	<a class="btn btn-outline-primary" href="../asigna">Asignar iniciativas</a>
 	{% endif %}
 	<a class="btn btn-outline-primary" href="..">Ver mis asignadas</a>
+  {% if g.user['rol'] != "escritor" %}
 	<a class="btn btn-outline-primary" href="../iniciativas">Ver todas las iniciativas</a>
+  {% endif %}
 	<a class="btn btn-outline-primary float-end" href="../logout">Terminar sesión</a>
 	<span class="btn btn-outline-secondary float-end disabled">Usuario: {{ g.user['usuario'] }}</span>
 	{% else %}

--- a/colabora/templates/edita.html
+++ b/colabora/templates/edita.html
@@ -7,8 +7,8 @@
 	{% if g.user['rol'] == 'admin' %}
 	<a class="btn btn-outline-primary" href="../asigna">Asignar iniciativas</a>
 	{% endif %}
-	<a class="btn btn-outline-primary" href="../iniciativas">Ver mis asignadas</a>
-	<a class="btn btn-outline-primary" href="..">Ver todas las iniciativas</a>
+	<a class="btn btn-outline-primary" href="..">Ver mis asignadas</a>
+	<a class="btn btn-outline-primary" href="../iniciativas">Ver todas las iniciativas</a>
 	<a class="btn btn-outline-primary float-end" href="../logout">Terminar sesión</a>
 	<span class="btn btn-outline-secondary float-end disabled">Usuario: {{ g.user['usuario'] }}</span>
 	{% else %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -214,7 +214,7 @@ def test_crea_error(client):
                                             'documento': 'documento1'})
     assert b'error: iniciativa 1 no creada' == response.data
 
-def test_edita(client):
+def test_edita_escritor(client):
     with client:
         response = client.post('/login',
                                data={'username': 'usuario1',
@@ -223,6 +223,9 @@ def test_edita(client):
         assert b'trata?' in response.data
         assert b'name="comentario"' not in response.data
         assert b'comentario1' in response.data
+        
+        assert b'href="..">Ver mis asignadas</a>' in response.data
+        assert b'href="../iniciativas">Ver todas las iniciativas</a>' in response.data
 
 def test_edita_sin_permiso(client):
     with client:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -225,6 +225,19 @@ def test_edita_escritor(client):
         assert b'comentario1' in response.data
         
         assert b'href="..">Ver mis asignadas</a>' in response.data
+        assert b'href="../iniciativas">Ver todas las iniciativas</a>' not in response.data
+
+def test_edita_editor(client):
+    with client:
+        response = client.post('/login',
+                               data={'username': 'usuario2',
+                                     'password': 'contrasena2'})
+        response = client.get('/edita/1')
+        assert b'trata?' in response.data
+        assert b'name="comentario"' in response.data
+        assert b'comentario1' in response.data
+        
+        assert b'href="..">Ver mis asignadas</a>' in response.data
         assert b'href="../iniciativas">Ver todas las iniciativas</a>' in response.data
 
 def test_edita_sin_permiso(client):


### PR DESCRIPTION
Se modificó la plantilla 'edita.html' para esconder la vista del botón para ver todas las iniciativas al rol de escritor.

Se agregó una prueba en el apartado de edita para el usuario editor.