### PR TITLE
Cambios a lista.html en /asigna, muestra estado de los usuarios

### DIFF
--- a/colabora/templates/lista.html
+++ b/colabora/templates/lista.html
@@ -27,18 +27,32 @@
 	{% if request.path == '/asigna' %}
 	<form class="needs-validation" novalidate method="post">
         <button class="btn btn-secondary" type="submit">Asignar</button>
-	{% for user in users %}
-	<div class="form-check">
-        <input class="form-check-input" type="radio" name="autor" value="{{ user.usuario }}" id="id{{ user.usuario }}" required>
-	<label class="form-check-label" for="id{{ user.usuario }}">{{ user.usuario }} {{ asignadas.get(user.usuario, {'Total':0})['Total'] }}
-	</label>
-	{% if loop.last %}
-	<div class="valid-feedback">Ok</div>
-	<div class="invalid-feedback">Selecciona un usuario</div>
-	{% endif %}
-	</div>
-        {% endfor %}
+  <div class="container">
+    <section class="section">
+      <table class="table table-hover">
+	      <tr class="tl"><th>Usuario</th><th>Cantidad</th><th>Nuevas</th><th>Pendientes</th><th>Revisadas</th>
+      {% for user in users %}
+        <tr>
+          <td>
+            <div class="form-check">
+              <input class="form-check-input" type="radio" name="autor" value="{{ user.usuario }}" id="id{{ user.usuario }}" required>
+              <label class="form-check-label" for="id{{ user.usuario }}">{{ user.usuario }}
+              </label>
+              {% if loop.last %}
+              <div class="valid-feedback">Ok</div>
+              <div class="invalid-feedback">Selecciona un usuario</div>
+              {% endif %}
+            </div>
+          </td>
+          <td>{{ asignadas.get(user.usuario, {'Total':0})['Total'] }}</td>
+          <td>{{ asignadas.get(user.usuario, {'Nueva':0})['Nueva'] }}</td>
+          <td>{{ asignadas.get(user.usuario, {'Pendiente':0})['Pendiente'] }}</td>
+          <td>{{ asignadas.get(user.usuario, {'Revisada':0})['Revisada'] }}</td>
+	    </tr>
+      {% endfor %}
+      </table>
 	{{ asignadas['']['Total'] }} por asignar
+
 	{% endif %}
     </div>
         {% for r in records %}


### PR DESCRIPTION
## Descripción:
Tabla expandida en la ruta "/asigna" de la vista de administrador, mostrando los estados de las iniciativas asignadas.

## Cambios realizados:
Cambios en "lista.html", se agregó el mismo formato de tabla de "lista_todas.html" incluyendo la columna para asignar.

## Razón de la modificación:
Se mejoró la vista de administrador para el mejor control de asignación de iniciativas.