### PR TITLE
Se modificó el parámetro language para arreglar un error de carga

### DIFF
--- a/colabora/templates/base.html
+++ b/colabora/templates/base.html
@@ -109,7 +109,7 @@ $(document).ready(function(){
     searching: false,
     paging: false,
     language: {
-        url: '//cdn.datatables.net/plug-ins/2.0.4/i18n/es-MX.json',
+        url: 'https://cdn.datatables.net/plug-ins/2.0.5/i18n/es-MX.json',
     },
   });
 });
@@ -117,7 +117,7 @@ $(document).ready(function(){
 </script>
 
 <script src="https://cdn.datatables.net/2.0.4/js/dataTables.js"></script>
-<script src="https://cdn.datatables.net/plug-ins/2.0.4/i18n/es-MX.json"></script>
+<script src="https://cdn.datatables.net/plug-ins/2.0.5/i18n/es-MX.json"></script>
 
 <div class="wrapper-footer">
   <div class="container">


### PR DESCRIPTION
## Descripción:
Se modificó la manera de obtener el enlace al parámetro de language en gridjs.

## Cambios realizados:
Se modificó a la versión más reciente del idioma español de México y el URL.

## Razón de la modificación:
El navegador Opera lanzaba un error al cargar la tabla con gridjs por errores de conexión con el archivo JSON del idioma.