### PR TITLE
Se mejoró el acceso a /cambia para que fuera restringido por una sesión

### DIFF
--- a/colabora/views.py
+++ b/colabora/views.py
@@ -179,8 +179,10 @@ def recupera():
 
         if val == True:
             _user_id = codigo.split('.')[0]
+            session['user_id'] = _user_id
+            session.permanent = False
             flash("Código validado correctamente.")
-            return redirect(url_for('cambia', _method="GET", user_id = _user_id))
+            return redirect(url_for('cambia', _method="GET"))
         else:
             error = 'No se ha podido validar el código.'
             flash(error)
@@ -188,7 +190,8 @@ def recupera():
 
 @app.route("/cambia", methods=('GET', 'POST'))
 def cambia():
-    user_id = request.args.get('user_id')
+    if 'user_id' not in session:
+        abort(403)
     if request.method == 'POST':
         password = request.form['password']
         db = get_db()
@@ -200,7 +203,9 @@ def cambia():
         if error is None:
             pwd_hash = generate_password_hash(password)
 
+            user_id = session['user_id']
             actualiza_usuario(db, user_id, contrasena=pwd_hash)
+            session.clear()
             flash("Contraseña cambiada correctamente.")
             return redirect(url_for("login_get"))
         flash(error)


### PR DESCRIPTION
## Descripción:
Se agregó una restricción para la ruta "/cambia", para que solo esté disponible a personas que tengan un ID registrado en una sesión temporal.

## Cambios realizados:
En la ruta "/recupera" se guarda el ID del usuario en una sesión temporal, que se utiliza a la hora de redirigir a "/cambia". En caso de no tener un ID de usuario en la sesión, se aborta a la ruta 403.

## Razón de la modificación:
Se asegura que se reciba un ID de usuario antes de cambiar la contraseña, y que sea accedida la ruta solo después de la ruta "/recupera", no desde afuera.