### PR TITLE
Issue 31

### DIFF
--- a/colabora/db.py
+++ b/colabora/db.py
@@ -367,3 +367,17 @@ def actualiza_usuario(db, usuario_id, usuario=None, contrasena=None,
             db.commit()
             return f"ok: usuario {usuario_id} actualizado"
     return f"error: usuario {usuario_id} no actualizado"
+
+def remueve_iniciativa(db, entidad, legislatura, numero):
+    cmd = ("DELETE FROM iniciativas WHERE "
+           "entidad_id = (SELECT entidad_id FROM entidad WHERE nombre=?) AND "
+           "legislatura_id = (SELECT legislatura_id FROM legislatura WHERE nombre=?) AND "
+           "numero = ?")
+    cur = db.cursor()
+    try:
+        desclasifica(db, entidad, legislatura, numero)
+        cur.execute(cmd, (entidad, legislatura, numero))
+        db.commit()
+    except sqlite3.DatabaseError:
+        return f"error: iniciativa {numero} no removida"
+    return f"ok: iniciativa {numero} removida"

--- a/colabora/db.py
+++ b/colabora/db.py
@@ -374,10 +374,12 @@ def remueve_iniciativa(db, entidad, legislatura, numero):
            "legislatura_id = (SELECT legislatura_id FROM legislatura WHERE nombre=?) AND "
            "numero = ?")
     cur = db.cursor()
-    try:
-        desclasifica(db, entidad, legislatura, numero)
-        cur.execute(cmd, (entidad, legislatura, numero))
-        db.commit()
-    except sqlite3.DatabaseError:
+    row = iniciativa(db, entidad, legislatura, numero)
+    if row is None:
         return f"error: iniciativa {numero} no removida"
+    elif row['usuario'] is not None:
+         return f"error: iniciativa {numero} no removida"
+    desclasifica(db, entidad, legislatura, numero)
+    cur.execute(cmd, (entidad, legislatura, numero))
+    db.commit()
     return f"ok: iniciativa {numero} removida"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -343,7 +343,12 @@ def test_remueve_iniciativa_ok(database):
     result = colabora.db.remueve_iniciativa(database, 'entidad1', 'legislatura1', 3)
     assert result == "ok: iniciativa 3 removida"
 
-def test_remueve_inciativa_error(database):
+def test_remueve_inciativa_error_asignada(database):
     database.executescript(_data_sql)
     result = colabora.db.remueve_iniciativa(database, 'entidad1', 'legislatura1', 1)
     assert result == "error: iniciativa 1 no removida"
+
+def test_remueve_inciativa_error_inexistente(database):
+    database.executescript(_data_sql)
+    result = colabora.db.remueve_iniciativa(database, 'entidad1', 'legislatura1', 1000)
+    assert result == "error: iniciativa 1000 no removida"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -337,3 +337,13 @@ def test_actualiza_iniciativa_cambios_documento(database):
     result = colabora.db.actualiza_iniciativa(database, 'entidad1', 'legislatura1', 1,
                                               cambios='CAMBIOS', documento='documento1')
     assert result == 'ok: iniciativa 1 actualizada'
+
+def test_remueve_iniciativa_ok(database):
+    database.executescript(_data_sql)
+    result = colabora.db.remueve_iniciativa(database, 'entidad1', 'legislatura1', 3)
+    assert result == "ok: iniciativa 3 removida"
+
+def test_remueve_inciativa_error(database):
+    database.executescript(_data_sql)
+    result = colabora.db.remueve_iniciativa(database, 'entidad1', 'legislatura1', 1)
+    assert result == "error: iniciativa 1 no removida"


### PR DESCRIPTION
## Descripción:
Se agregó la función db.remueve_iniciativa, junto con las pruebas correspondientes en casos de éxito o de falla.

## Cambios realizados:
Se agregaron 3 funciones de prueba, en caso de éxito, en caso de falla por iniciativa inexistente y en caso de falla por iniciativa que ya está asignada a un usuario.
Se creó la función en db.py.

## Razón de la modificación:
Se utilizará la función en una API para modificaciones a iniciativas.