### PR TITLE
Función db.remueve_usuario

### DIFF
--- a/colabora/db.py
+++ b/colabora/db.py
@@ -383,3 +383,13 @@ def remueve_iniciativa(db, entidad, legislatura, numero):
     cur.execute(cmd, (entidad, legislatura, numero))
     db.commit()
     return f"ok: iniciativa {numero} removida"
+
+def remueve_usuario(db, usuario_id):
+    cmd = ("DELETE FROM usuarios WHERE usuario_id = ?")
+    cur = db.cursor()
+    try:
+        cur.execute(cmd, (usuario_id,))
+        db.commit()
+    except sqlite3.DatabaseError:
+        return f"error: usuario {usuario_id} no removido"
+    return f"ok: usuario {usuario_id} removido"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -352,3 +352,13 @@ def test_remueve_inciativa_error_inexistente(database):
     database.executescript(_data_sql)
     result = colabora.db.remueve_iniciativa(database, 'entidad1', 'legislatura1', 1000)
     assert result == "error: iniciativa 1000 no removida"
+
+def test_remueve_usuario(database):
+    database.executescript(_data_sql)
+    result = colabora.db.remueve_usuario(database, 4)
+    assert result == "ok: usuario 4 removido"
+
+def test_remueve_usuario_error(database):
+    database.executescript(_data_sql)
+    result = colabora.db.remueve_usuario(database, 1)
+    assert result == "error: usuario 1 no removido"


### PR DESCRIPTION
## Descripción:
Se agregó una función para eliminar usuarios.

## Cambios realizados:
Se agregaron pruebas de error y de aceptación en test_db, para usuarios que tienen o no iniciativas asignadas.
Se agregó una función de remueve_usuarios en db, intentando eliminar el usuario que corresponde al ID. Si hay un error, significa que tiene alguna iniciativa asignada.

## Razón de la modificación:
Se utilizará para eliminar usuarios sin actividad.