### PR TITLE
Se agregó la funcionalidad de desasignar iniciativas

### DIFF
--- a/colabora/templates/lista_desasigna.html
+++ b/colabora/templates/lista_desasigna.html
@@ -1,15 +1,22 @@
 {% extends "base.html" %}
-{% block title %}Iniciativas sin resumen - Legislatura LXIII{% endblock %}
+{% block title %}Iniciativas asignadas - Legislatura LXIII{% endblock %}
 {% block content %}
     <div class="container">
       <p>
 	{% if g.user %}
 	&nbsp;
-	{% if g.user['rol'] == 'admin' %}
-	<a class="btn btn-outline-primary" href="asigna">Asignar iniciativas</a>
+	{% if g.user['rol'] == 'admin' and request.path != '/desasigna' %}
 	<a class="btn btn-outline-primary" href="desasigna">Desasignar iniciativas</a>
 	{% endif %}
+	{% if request.path == '/desasigna' %}
 	<a class="btn btn-outline-primary" href=".">Ver mis asignadas</a>
+	{% endif %}
+	{% if request.path in ('/', '/desasigna') and g.user['rol'] != 'escritor' %}
+	<a class="btn btn-outline-primary" href="iniciativas">Ver todas las iniciativas</a>
+	{% endif %}
+	{% if request.path == '/iniciativas' %}
+	<a class="btn btn-outline-primary" href=".">Ver mis asignadas</a>
+	{% endif %}
 	<a class="btn btn-outline-primary float-end" href="logout">Terminar sesión</a>
 	<a class="btn btn-outline-primary float-end" href="usuario">Usuario: {{ g.user['usuario'] }}</a>
 	{% else %}
@@ -17,10 +24,12 @@
 	<a class="btn btn-outline-primary" href="registro">Registrar nuevo usuario</a>
 	{% endif %}
       </p>
-    </div>
+	{% if request.path == '/desasigna' %}
+	<form class="needs-validation" novalidate method="post">
+        <button class="btn btn-secondary" type="submit">Desasignar</button>
   <div class="container">
     <section class="section">
-      <table class="table table-hover" id="asignadas" style="width:100%;">
+      <table class="table table-hover" id="asignadas">
         <thead>
             <tr class="tl">
                 <th>Usuario</th>
@@ -31,36 +40,50 @@
             </tr>
         </thead>
         <tbody>
-            {% for usuario in asignadas_usuario|sort %}
+            {% for user in users | sort(attribute='usuario') %}
             <tr>
-                <td><a href="#h{{ loop.index }}">{% if usuario == '' %}Sin asignar{% else %}{{ usuario }}{% endif %}</a></td>
-                <td>{{ asignadas[usuario]['Total'] }}</td>
-                <td>{{ asignadas[usuario]['Nueva'] }}</td>
-                <td>{{ asignadas[usuario]['Pendiente'] }}</td>
-                <td>{{ asignadas[usuario]['Revisada'] }}</td>
+                <td>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="autor" value="{{ user.usuario }}" id="id{{ user.usuario }}" required>
+                        <label class="form-check-label" for="id{{ user.usuario }}">{{ user.usuario }}</label>
+                        {% if loop.last %}
+                        <div class="valid-feedback">Ok</div>
+                        <div class="invalid-feedback">Selecciona un usuario</div>
+                        {% endif %}
+                    </div>
+                </td>
+                <td>{{ asignadas.get(user.usuario, {'Total':0})['Total'] }}</td>
+                <td>{{ asignadas.get(user.usuario, {'Nueva':0})['Nueva'] }}</td>
+                <td>{{ asignadas.get(user.usuario, {'Pendiente':0})['Pendiente'] }}</td>
+                <td>{{ asignadas.get(user.usuario, {'Revisada':0})['Revisada'] }}</td>
             </tr>
             {% endfor %}
         </tbody>
-    </table>
-  </div>
-    {% for usuario in asignadas_usuario|sort %}
-    <div class="container">
-      {% if usuario == '' %}
-      <h2 id="h{{ loop.index }}">Sin asignar  - {{ asignadas[usuario]['Total'] }}</h2>
-      {% else %}
-      <h2 id="h{{ loop.index }}">{{ usuario }} - {{ asignadas[usuario]['Total'] }}</h2>
-      {% endif %}
+    </table>    
+      </div>
+	{{ asignadas['']['Total'] }} por asignar
+	{% endif %}
+    <h3 class="alert alert-danger">Favor de usar con cuidado.</h2>
     </div>
-    {% for r in asignadas_usuario[usuario] %}
+    {% for usuario, iniciativas_user in iniciativas_por_usuario.items() | sort%}
+    <div class="container">
+        <h2 id="h{{ loop.index }}">{{ usuario }} - {{ iniciativas_user|length }}</h2>
+    </div>
+    {% for r in iniciativas_user %}
     <div class="container px-4">
       <div class="row py-2 bg-light border-bottom-0 border">
         <div class="col-md-3">
           <div class=""><b>Número</b> {{ r.numero }}
           </div>
         </div>
-          <div class="col-md-3">
-            <div class=""><b>Asignada</b> {% if r.usuario != None %}{{ r.usuario }}{% endif %}</div>
+        <div class="col-md-3">
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" name="numero" value="{{ r.numero }}" id="c{{ r.numero }}" {% if r.estado != None %}disabled{% endif %}>
+            <label class="form-check-label" for="c{{ r.numero }}"><b>Desasignar</b></label>
+            <div class="valid-feedback">Ok</div>
+            <div class="invalid-feedback">Selecciona una o más iniciativas</div>
           </div>
+        </div>
         <div class="col-md-6">
           <div class=""><b>Estado</b> {% if r.estado != None %}{{ r.estado }}{% endif %}
           </div>
@@ -112,7 +135,8 @@
 </div>
 </div>
 <br>
-      {% endfor %}
-      {% endfor %}
+</div>
+{% endfor %}
+{% endfor %}
       </form>
 {% endblock %}

--- a/colabora/templates/usuario.html
+++ b/colabora/templates/usuario.html
@@ -6,6 +6,9 @@
 	{% if g.user %}
 	<a class="btn btn-outline-primary" href=".">Ver mis asignadas</a>
 	<a class="btn btn-outline-primary" href="iniciativas">Ver todas las iniciativas</a>
+	{% if g.user['rol'] == 'admin'%}
+	<a class="btn btn-outline-primary" href="desasigna">Desasignar iniciativas</a>
+	{% endif %}
 	<a class="btn btn-outline-primary float-end" href="logout">Terminar sesión</a>
 	<span class="btn btn-outline-secondary float-end disabled">Usuario: {{ g.user['usuario'] }}</span>
 	{% else %}

--- a/colabora/views.py
+++ b/colabora/views.py
@@ -13,9 +13,11 @@ from itsdangerous import TimestampSigner
 from .app import app
 from .db import get_db
 from .db import iniciativas_asignadas
+from .db import obtener_iniciativas
 from .db import iniciativas, areas as dbareas, usuarios
 from .db import cantidad_asignadas_por_usuario
 from .db import asigna as dbasigna
+from .db import desasigna as dbdesasigna
 from .db import agrega_iniciativa
 from .db import iniciativa
 from .db import areas_por_iniciativa
@@ -266,7 +268,33 @@ def asigna():
         comentarios=comentarios, users=users, asignadas=asignadas, roles=roles,
         temas=temas, resumenes=resumenes
     )
-
+    
+@app.route("/desasigna", methods=["GET", "POST"])
+@login_required
+def desasigna():
+    db = get_db()
+    roles = {d['usuario']: d['rol'] for d in usuarios(db)}
+    if g.user['rol'] != 'admin':
+        abort(403)
+    if request.method == 'POST':
+        for numero in request.form.getlist('numero'):
+            result = dbdesasigna(db, ENTIDAD, LEGISLATURA, numero)
+            print(result)
+    records = obtener_iniciativas(db, ENTIDAD, LEGISLATURA,
+                          solo_asignadas=True)
+    tags, comentarios, areas, users, asignadas, temas, resumenes = valores(records)
+    
+    iniciativas_por_usuario = {}
+    for record in records:
+        if record['usuario'] not in iniciativas_por_usuario:
+            iniciativas_por_usuario[record['usuario']] = []
+        iniciativas_por_usuario[record['usuario']].append(record)
+    
+    return render_template(
+        "lista_desasigna.html", iniciativas_por_usuario=iniciativas_por_usuario, tags=tags, areas=areas,
+        comentarios=comentarios, users=users, asignadas=asignadas, roles=roles,
+        temas=temas, resumenes=resumenes
+    )
 
 @app.route("/crea/<numero>", methods=['POST'])
 def crea(numero):


### PR DESCRIPTION
## Descripción:
Se creó una nueva ruta donde ahora los administradores pueden desasignar iniciativas.

## Cambios realizados:
- Se creó una nueva ruta en views.py llamada /desasigna
- Se añadió un botón en /usuarios que lleva a la ruta /desasigna
- Se creó un nuevo archivo llamado lista_desasigna.html basado en lista.html y lista_todas.html
- Se creó una nueva función en db.py llamada desasigna() para eliminar la asignación de la base de datos

## Razón de la modificación:
Ahora se pueden desasignar iniciativas sin Estado en caso de ser asignadas por algún error o por cualquier oto motivo razonable. Su funcionalidad se basa en /asigna de manera que los administradores estén familiarizados con la nueva ruta.