### PR TITLE
Buscador de temas

### DIFF
--- a/colabora/db.py
+++ b/colabora/db.py
@@ -450,7 +450,7 @@ def remueve_usuario(db, usuario_id):
 
 def temas_creados(db):
     """Regresa una tupla de los temas creados"""
-    cmd = "SELECT tema FROM iniciativas WHERE tema !=''"
+    cmd = "SELECT DISTINCT tema FROM iniciativas WHERE tema !=''"
     cur = db.cursor()
     cur.execute(cmd)
     records = cur.fetchall()

--- a/colabora/db.py
+++ b/colabora/db.py
@@ -447,3 +447,11 @@ def remueve_usuario(db, usuario_id):
     except sqlite3.DatabaseError:
         return f"error: usuario {usuario_id} no removido"
     return f"ok: usuario {usuario_id} removido"
+
+def temas_creados(db):
+    """Regresa una lista de los temas creados"""
+    cmd = "SELECT tema FROM iniciativas"
+    cur = db.cursor()
+    cur.execute(cmd)
+    records = cur.fetchall()
+    return records

--- a/colabora/db.py
+++ b/colabora/db.py
@@ -450,7 +450,7 @@ def remueve_usuario(db, usuario_id):
 
 def temas_creados(db):
     """Regresa una tupla de los temas creados"""
-    cmd = "SELECT tema FROM iniciativas"
+    cmd = "SELECT tema FROM iniciativas WHERE tema !=''"
     cur = db.cursor()
     cur.execute(cmd)
     records = cur.fetchall()

--- a/colabora/db.py
+++ b/colabora/db.py
@@ -449,7 +449,7 @@ def remueve_usuario(db, usuario_id):
     return f"ok: usuario {usuario_id} removido"
 
 def temas_creados(db):
-    """Regresa una lista de los temas creados"""
+    """Regresa una tupla de los temas creados"""
     cmd = "SELECT tema FROM iniciativas"
     cur = db.cursor()
     cur.execute(cmd)

--- a/colabora/templates/edita.html
+++ b/colabora/templates/edita.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Iniciativas sin resumen - Legislatura LXIII{% endblock %}
 {% block content %}
+<script src="https://unpkg.com/htmx.org@2.0.2" integrity="sha384-Y7hw+L/jvKeWIRRkqWYfPcvVxHzVzn5REgzbawhxAuQGwX1XWe70vji+VSeHOThJ" crossorigin="anonymous"></script>
     <div class="container">
       <p>
 	{% if g.user %}

--- a/colabora/templates/edita.html
+++ b/colabora/templates/edita.html
@@ -56,8 +56,25 @@
       </div>
       <div class="row py-2 border border-top-0 bg-light">
           <div class="col-md-3"><b>Tema</b>
-            <textarea class="form-control" name="tema">{{ r.tema }}</textarea>
+            <span class="htmx-indicator"> 
+              <p>Cargando temas...</p>
+            </span> 
+            <textarea class="form-control" name="tema"
+                      placeholder="Empieza a escribir para ver sugerencias"
+                      hx-post="/buscar" 
+                      hx-trigger="input changed delay:500ms, search" 
+                      hx-target="#resultados" 
+                      hx-indicator=".htmx-indicator"
+                      >
+                      {{ r.tema }}
+            </textarea>
             <a class="form-text" class="link-primary" href="https://siguealcongreso.org/resumenes/criterios-para-resumenes/">¿De qué trata?</a>
+            <div class="col-md-3 w-100 overflow-auto" style="height: 10rem;">
+              <table class="table table-sm fs-6">
+                <tbody id="resultados">
+                </tbody>
+              </table>
+          </div>
           </div>
           <div class="col-md-6"><b>Resumen</b>
             <textarea class="form-control" rows="5" name="resumen">{{ r.resumen }}</textarea>

--- a/colabora/templates/edita.html
+++ b/colabora/templates/edita.html
@@ -117,7 +117,7 @@
 </div>
 <script>
   function llenarTema(value){
-      document.getElementById('tema-input').value = value;
+      document.getElementById('tema-input').value = value.trim();
   }
 </script>
 {% endblock %}

--- a/colabora/templates/edita.html
+++ b/colabora/templates/edita.html
@@ -61,10 +61,11 @@
                       placeholder="Empieza a escribir para ver sugerencias"
                       hx-post="/buscar" 
                       hx-trigger="input changed delay:500ms, search" 
-                      hx-target="#resultados" 
+                      hx-target="#resultados"
+                      rows="3"
                       >{{ r.tema }}</textarea>
             <a class="form-text" class="link-primary" href="https://siguealcongreso.org/resumenes/criterios-para-resumenes/">¿De qué trata?</a>
-            <div class="col-md-3 w-100 overflow-auto" style="height: 10rem;">
+            <div class="col-md-3 w-100 overflow-auto" style="max-height: 10rem;">
               <table class="table table-sm fs-6">
                 <tbody id="resultados">
                 </tbody>

--- a/colabora/templates/edita.html
+++ b/colabora/templates/edita.html
@@ -62,9 +62,7 @@
                       hx-post="/buscar" 
                       hx-trigger="input changed delay:500ms, search" 
                       hx-target="#resultados" 
-                      >
-                      {{ r.tema }}
-            </textarea>
+                      >{{ r.tema }}</textarea>
             <a class="form-text" class="link-primary" href="https://siguealcongreso.org/resumenes/criterios-para-resumenes/">¿De qué trata?</a>
             <div class="col-md-3 w-100 overflow-auto" style="height: 10rem;">
               <table class="table table-sm fs-6">

--- a/colabora/templates/edita.html
+++ b/colabora/templates/edita.html
@@ -57,6 +57,7 @@
       <div class="row py-2 border border-top-0 bg-light">
           <div class="col-md-3"><b>Tema</b>
             <textarea class="form-control" name="tema"
+                      id="tema-input"
                       placeholder="Empieza a escribir para ver sugerencias"
                       hx-post="/buscar" 
                       hx-trigger="input changed delay:500ms, search" 
@@ -116,4 +117,9 @@
 </form>
 </div>
 </div>
+<script>
+  function llenarTema(value){
+      document.getElementById('tema-input').value = value;
+  }
+</script>
 {% endblock %}

--- a/colabora/templates/edita.html
+++ b/colabora/templates/edita.html
@@ -56,15 +56,11 @@
       </div>
       <div class="row py-2 border border-top-0 bg-light">
           <div class="col-md-3"><b>Tema</b>
-            <span class="htmx-indicator"> 
-              <p>Cargando temas...</p>
-            </span> 
             <textarea class="form-control" name="tema"
                       placeholder="Empieza a escribir para ver sugerencias"
                       hx-post="/buscar" 
                       hx-trigger="input changed delay:500ms, search" 
                       hx-target="#resultados" 
-                      hx-indicator=".htmx-indicator"
                       >
                       {{ r.tema }}
             </textarea>

--- a/colabora/views.py
+++ b/colabora/views.py
@@ -28,6 +28,7 @@ from .db import estados as dbestados
 from .db import agrega_usuario
 from .db import asignadas_por_usuario
 from .db import actualiza_usuario
+from .db import temas_creados
 from .util import revisa_tema
 
 ENTIDAD = 'Jalisco'
@@ -324,6 +325,22 @@ def edita_post(numero):
     flash("Información guardada")
     return redirect(url_for('edita', numero=numero))
 
+@app.route('/buscar', methods=['POST'])
+def buscar_tema():
+    db = get_db()
+    input_usuario = request.form.get('tema', '').strip().lower()
+    filas = ''
+    if not input_usuario:
+        results = temas_creados(db)
+    else:
+        results = [tema for tema in temas_creados(db) if input_usuario in tema[0].lower()]
+    for result in results:
+        filas += f"""
+        <tr>
+            <td>{result[0]}</td>
+        </tr>
+        """
+    return filas
 
 @app.before_request
 def load_logged_in_user():

--- a/colabora/views.py
+++ b/colabora/views.py
@@ -326,14 +326,16 @@ def edita_post(numero):
     return redirect(url_for('edita', numero=numero))
 
 @app.route('/buscar', methods=['POST'])
+@login_required
 def buscar_tema():
     db = get_db()
-    input_usuario = request.form.get('tema', '').strip().lower()
+    table = str.maketrans("áéíóúñ","aeioun")
+    input_usuario = request.form.get('tema', '').strip().lower().translate(table)
     filas = ''
     if not input_usuario:
-        results = temas_creados(db)
+        results = []
     else:
-        results = [tema for tema in temas_creados(db) if input_usuario in tema[0].lower()]
+        results = [tema for tema in temas_creados(db) if input_usuario in tema[0].lower().translate(table)]
     for result in results:
         estado, correcciones = revisa_tema(result[0])
         if estado == "Ok":

--- a/colabora/views.py
+++ b/colabora/views.py
@@ -335,15 +335,17 @@ def buscar_tema():
     else:
         results = [tema for tema in temas_creados(db) if input_usuario in tema[0].lower()]
     for result in results:
-        filas += f"""
-        <tr>
-            <td ondblclick="llenarTema('{result[0]}')"
-                class="user-select-none"
-                style="cursor: pointer;">
-                {result[0]}
-            </td>
-        </tr>
-        """
+        estado, correcciones = revisa_tema(result[0])
+        if estado == "Ok":
+            filas += f"""
+            <tr>
+                <td ondblclick="llenarTema('{result[0]}')"
+                    class="user-select-none"
+                    style="cursor: pointer;">
+                    {result[0]}
+                </td>
+            </tr>
+            """
     return filas
 
 @app.before_request

--- a/colabora/views.py
+++ b/colabora/views.py
@@ -337,7 +337,11 @@ def buscar_tema():
     for result in results:
         filas += f"""
         <tr>
-            <td>{result[0]}</td>
+            <td ondblclick="llenarTema('{result[0]}')"
+                class="user-select-none"
+                style="cursor: pointer;">
+                {result[0]}
+            </td>
         </tr>
         """
     return filas

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -508,18 +508,18 @@ def test_buscar_tema_no_input(client):
     response = client.post('/buscar',
                            data={'tema': ''})
     assert response.status == '200 OK'
-    assert b"<td>tema1</td>" in response.data
-    assert b"<td>tema3</td>" in response.data
+    assert b'<td ondblclick="llenarTema(\'tema1\')"' in response.data
+    assert b'<td ondblclick="llenarTema(\'tema3\')"' in response.data
 
 def test_buscar_tema_input(client):
     response = client.post('/buscar',
                            data={'tema': '1'})
     assert response.status == '200 OK'
-    assert b"<td>tema1</td>" in response.data
+    assert b'<td ondblclick="llenarTema(\'tema1\')"' in response.data
 
 def test_buscar_tema_no_resultados(client):
     response = client.post('/buscar',
                            data={'tema': 'tema4'})
     assert response.status == '200 OK'
-    assert b"<td>tema1</td>" not in response.data
-    assert b"<td>tema3</td>" not in response.data
+    assert b'<td ondblclick="llenarTema(\'tema1\')"' not in response.data
+    assert b'<td ondblclick="llenarTema(\'tema3\')"' not in response.data

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -503,3 +503,23 @@ def test_cambia_en_session_enviar_ok(client):
     assert response.history[0].status == '302 FOUND'
     assert response.request.path == "/login"
     assert 'Contraseña cambiada correctamente.' in response.data.decode()
+
+def test_buscar_tema_no_input(client):
+    response = client.post('/buscar',
+                           data={'tema': ''})
+    assert response.status == '200 OK'
+    assert b"<td>tema1</td>" in response.data
+    assert b"<td>tema3</td>" in response.data
+
+def test_buscar_tema_input(client):
+    response = client.post('/buscar',
+                           data={'tema': '1'})
+    assert response.status == '200 OK'
+    assert b"<td>tema1</td>" in response.data
+
+def test_buscar_tema_no_resultados(client):
+    response = client.post('/buscar',
+                           data={'tema': 'tema4'})
+    assert response.status == '200 OK'
+    assert b"<td>tema1</td>" not in response.data
+    assert b"<td>tema3</td>" not in response.data

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -504,20 +504,40 @@ def test_cambia_en_session_enviar_ok(client):
     assert response.request.path == "/login"
     assert 'Contraseña cambiada correctamente.' in response.data.decode()
 
+def test_buscar_reenvia_a_login(client):
+    response = client.post('/buscar', follow_redirects=True)
+    assert len(response.history) == 1
+    assert response.history[0].status == '302 FOUND'
+    assert response.request.path == "/login"
+
 def test_buscar_tema_no_input(client):
+    with client.session_transaction() as session:
+        session['uid'] = 1
     response = client.post('/buscar',
                            data={'tema': ''})
     assert response.status == '200 OK'
-    assert b'<td ondblclick="llenarTema(\'tema1\')"' in response.data
-    assert b'<td ondblclick="llenarTema(\'tema3\')"' in response.data
+    assert b'<td ondblclick="llenarTema(\'tema1\')"' not in response.data
+    assert b'<td ondblclick="llenarTema(\'tema3\')"' not in response.data
 
 def test_buscar_tema_input(client):
+    with client.session_transaction() as session:
+        session['uid'] = 1
     response = client.post('/buscar',
                            data={'tema': '1'})
     assert response.status == '200 OK'
     assert b'<td ondblclick="llenarTema(\'tema1\')"' in response.data
 
+def test_buscar_tema_input_acento(client):
+    with client.session_transaction() as session:
+        session['uid'] = 1
+    response = client.post('/buscar',
+                           data={'tema': 'téma1'})
+    assert response.status == '200 OK'
+    assert b'<td ondblclick="llenarTema(\'tema1\')"' in response.data
+
 def test_buscar_tema_no_resultados(client):
+    with client.session_transaction() as session:
+        session['uid'] = 1
     response = client.post('/buscar',
                            data={'tema': 'tema4'})
     assert response.status == '200 OK'

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -367,3 +367,9 @@ def test_remueve_usuario_error(database):
     database.executescript(_data_sql)
     result = colabora.db.remueve_usuario(database, 1)
     assert result == "error: usuario 1 no removido"
+
+def test_temas_creados(database):
+    database.executescript(_data_sql)
+    result = colabora.db.temas_creados(database)
+    assert result[0][0] == "tema1"
+    assert result[1][0] == "tema3"


### PR DESCRIPTION
## Descripción:
Se agregó la función de obtener sugerencias de temas ya existentes dentro de la app mientras se escriben.

## Cambios realizados:
Se creó una función `temas_creados` para obtener todos los temas de las iniciativas sin duplicados. 

Se modificó el template `edita.html` para mostrar temas basado en lo que el usuario escriba, utilizando htmx para hacer POST a una ruta nueva, `/buscar`, que utiliza `temas_creados` y regresa los temas que cumplan con los criterios de la app en formato de tabla.

Cada fila puede llamar la función `llenarTema()` con doble click que se encuentra en `edita.html`, para que el usuario llene el tema con el ya existente si así lo desea. 

## Razón de la modificación:
Será más sencillo para los usuarios identificar qué temas ya existentes pueden utilizar para llenar ese campo, para que haya más consistencia en la app web.