### PR TITLE
Mostrar entidad y legislatura - Versión B

### DIFF
--- a/colabora/templates/base.html
+++ b/colabora/templates/base.html
@@ -77,6 +77,10 @@
 </div>
 {% endwith %}
 
+{% if g.user %}
+  {% include 'entidad_legislatura.html' %}
+{% endif %}
+
 {% block content %}{% endblock %}
 
 <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>

--- a/colabora/templates/entidad_legislatura.html
+++ b/colabora/templates/entidad_legislatura.html
@@ -1,0 +1,8 @@
+<div class="container">
+    <div class="btn-group">
+        <button class="btn btn-outline-secondary" disabled>{{ g.user['entidad'] }} - {{ g.user['legislatura'] }}</button>
+        <button class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" disabled data-bs-toggle="dropdown" aria-expanded="false" >
+          <span class="visually-hidden">Toggle Dropdown</span>
+        </button>
+    </div>
+</div>

--- a/colabora/templates/entidad_legislatura.html
+++ b/colabora/templates/entidad_legislatura.html
@@ -1,8 +1,5 @@
-<div class="container">
+<div class="container d-grid">
     <div class="btn-group">
         <button class="btn btn-outline-secondary" disabled>{{ g.user['entidad'] }} - {{ g.user['legislatura'] }}</button>
-        <button class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" disabled data-bs-toggle="dropdown" aria-expanded="false" >
-          <span class="visually-hidden">Toggle Dropdown</span>
-        </button>
     </div>
 </div>


### PR DESCRIPTION
## Descripción:
Se añadió un botón deshabilitado que muestra la entidad y la legislatura actual del usuario.

## Cambios realizados:

- Se cambió el template base.html para mostrar la entidad y legislatura solo cuando hay un usuario.
- Se creó un nuevo template llamado entidad_legislatura.html que despliga un botón deshabilitado con la legislatura y la entidad del usuario.

## Razón de la modificación:

Preparación para el issue 76, dónde el usuario podrá cambiar su entidad y legislatura.