### PR TITLE
Incluir la medición de branch coverage

### DIFF
--- a/tests/data.sql
+++ b/tests/data.sql
@@ -4,7 +4,7 @@ INSERT INTO legislatura (nombre, entidad_id) VALUES ('legislatura1', 1);
 INSERT INTO legislatura (nombre, entidad_id) VALUES ('legislatura2', 1);
 INSERT INTO legislatura (nombre, entidad_id) VALUES ('legislatura1', 2);
 INSERT INTO legislatura (nombre, entidad_id) VALUES ('legislatura3', 1);
-INSERT INTO estado (estado) VALUES ('estado1');
+INSERT INTO estado (estado) VALUES ('Pendiente');
 
 INSERT INTO areas (nombre)
 VALUES ('area1');
@@ -42,10 +42,10 @@ VALUES
 );
 
 INSERT INTO iniciativas (legislatura_id, numero,
-cambios, documento, tema, resumen, comentario)
+cambios, documento, tema, resumen, comentario, estado_id)
 VALUES
 ((SELECT legislatura_id FROM legislatura WHERE nombre='legislatura3'),
- 4, 'Cambios 4', 'documento4', 'tema4', 'resumen4', 'comentario4'
+ 4, 'Cambios 4', 'documento4', 'tema4', 'resumen4', 'comentario4', 1
 );
 
 INSERT INTO clasificacion (legislatura_id, numero, area_id) VALUES

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -79,6 +79,12 @@ def test_actualiza_usuario_error(database):
     result = colabora.db.actualiza_usuario(database, usuario_id=1)
     assert 'error: usuario 1 no actualizado' in result
 
+def test_actualiza_usuario_id_inexistente(database):
+    database.executescript(_data_sql)
+    result = colabora.db.actualiza_usuario(database, usuario_id=99,
+                                           rol='escritor')
+    assert 'error: usuario 99 no actualizado' in result
+
 def test_actualiza_usuario_contrasena(database):
     database.executescript(_data_sql)
     result = colabora.db.actualiza_usuario(database, usuario_id=1,
@@ -114,7 +120,7 @@ def test_estados(database):
     database.executescript(_data_sql)
     result = colabora.db.estados(database)
     assert len(result) == 1
-    assert "estado1" == result[0]["estado"]
+    assert "Pendiente" == result[0]["estado"]
 
 
 def test_areas(database):
@@ -153,7 +159,7 @@ def test_cantidad_asignadas_por_usuario_todas_asignadas(database):
     database.executescript(_data_sql)
     result = colabora.db.cantidad_asignadas_por_usuario(database, entidad= 'entidad1', legislatura= 'legislatura3')
     assert len(result) == 2
-    assert result == {'': {'Total': 0, 'Nueva': 0, 'Pendiente': 0, 'Revisada': 0}, 'usuario1': {'Total': 1, 'Nueva': 1, 'Pendiente': 0, 'Revisada': 0}}
+    assert result == {'': {'Total': 0, 'Nueva': 0, 'Pendiente': 0, 'Revisada': 0}, 'usuario1': {'Total': 1, 'Nueva': 0, 'Pendiente': 1, 'Revisada': 0}}
 
 def test_asignadas_por_usuario(database):
     database.executescript(_data_sql)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,3 +19,8 @@ def test_revisa_tema_correcto():
     tema = 'Salud'
     result = revisa_tema(tema)
     assert result == ('Ok', [])
+
+def test_revisa_tema_nulo():
+    tema = None
+    result = revisa_tema(tema)
+    assert result == ('Ok', [])


### PR DESCRIPTION
## Descripción:
Se modificaron pruebas para cubrir las líneas de código no ejecutadas según el reporte de branch coverage.

## Cambios realizados:
Se agregó una prueba extra en `test_util.py` para probar un tema vacío.
Se agregaron dos pruebas y se modificaron los datos de prueba, para incluir el valor de estado en una iniciativa.

## Razón de la modificación:
Se desea alcanzar el 100% de coverage en Colabora.