### PR TITLE
Modificar enlaces de iniciativas

### DIFF
--- a/colabora/templates/edita.html
+++ b/colabora/templates/edita.html
@@ -49,7 +49,7 @@
         <div class="">
           <div class="">
               <b>Cambios</b> {{ r.cambios }}
-                (<a href="https://siguealcongreso.org/monitoreo/iniciativas/{{ g.user['legislatura'].lower() }}/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
+                (<a href="https://siguealcongreso.org/iniciativas/{{ g.user['legislatura'].lower() }}/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
             <a href="https://congresoweb.congresojal.gob.mx/infolej/sistemaintegral/infolej/{{ r.documento }}" target="_blank" title="Leer el documento">🖹</a>
           </div>
         </div>

--- a/colabora/templates/edita.html
+++ b/colabora/templates/edita.html
@@ -49,7 +49,7 @@
         <div class="">
           <div class="">
               <b>Cambios</b> {{ r.cambios }}
-                (<a href="https://siguealcongreso.org/monitoreo/iniciativas/lxiii/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
+                (<a href="https://siguealcongreso.org/monitoreo/iniciativas/<legislatura>/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
             <a href="https://congresoweb.congresojal.gob.mx/infolej/sistemaintegral/infolej/{{ r.documento }}" target="_blank" title="Leer el documento">🖹</a>
           </div>
         </div>

--- a/colabora/templates/edita.html
+++ b/colabora/templates/edita.html
@@ -49,7 +49,7 @@
         <div class="">
           <div class="">
               <b>Cambios</b> {{ r.cambios }}
-                (<a href="https://siguealcongreso.org/monitoreo/iniciativas/<legislatura>/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
+                (<a href="https://siguealcongreso.org/monitoreo/iniciativas/{{ g.user['legislatura'].lower() }}/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
             <a href="https://congresoweb.congresojal.gob.mx/infolej/sistemaintegral/infolej/{{ r.documento }}" target="_blank" title="Leer el documento">🖹</a>
           </div>
         </div>

--- a/colabora/templates/lista.html
+++ b/colabora/templates/lista.html
@@ -92,7 +92,7 @@
         <div class="">
           <div class="">
               <b>Cambios</b> {{ r.cambios }}
-                (<a href="https://siguealcongreso.org/monitoreo/iniciativas/lxiii/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
+                (<a href="https://siguealcongreso.org/monitoreo/iniciativas/<legislatura/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
             <a href="https://congresoweb.congresojal.gob.mx/infolej/sistemaintegral/infolej/{{ r.documento }}" target="_blank" title="Leer el documento">🖹</a>
             {% if g.user and (r.usuario == g.user['usuario'] or g.user['rol'] in ('editor', 'admin')) %}
 	    <a href="edita/{{ r.numero }}" title="Editar">✏</a>

--- a/colabora/templates/lista.html
+++ b/colabora/templates/lista.html
@@ -92,7 +92,7 @@
         <div class="">
           <div class="">
               <b>Cambios</b> {{ r.cambios }}
-                (<a href="https://siguealcongreso.org/monitoreo/iniciativas/<legislatura/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
+                (<a href="https://siguealcongreso.org/monitoreo/iniciativas/{{ g.user['legislatura'].lower() }}/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
             <a href="https://congresoweb.congresojal.gob.mx/infolej/sistemaintegral/infolej/{{ r.documento }}" target="_blank" title="Leer el documento">🖹</a>
             {% if g.user and (r.usuario == g.user['usuario'] or g.user['rol'] in ('editor', 'admin')) %}
 	    <a href="edita/{{ r.numero }}" title="Editar">✏</a>

--- a/colabora/templates/lista.html
+++ b/colabora/templates/lista.html
@@ -92,7 +92,7 @@
         <div class="">
           <div class="">
               <b>Cambios</b> {{ r.cambios }}
-                (<a href="https://siguealcongreso.org/monitoreo/iniciativas/{{ g.user['legislatura'].lower() }}/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
+                (<a href="https://siguealcongreso.org/iniciativas/{{ g.user['legislatura'].lower() }}/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
             <a href="https://congresoweb.congresojal.gob.mx/infolej/sistemaintegral/infolej/{{ r.documento }}" target="_blank" title="Leer el documento">🖹</a>
             {% if g.user and (r.usuario == g.user['usuario'] or g.user['rol'] in ('editor', 'admin')) %}
 	    <a href="edita/{{ r.numero }}" title="Editar">✏</a>

--- a/colabora/templates/lista_todas.html
+++ b/colabora/templates/lista_todas.html
@@ -69,7 +69,7 @@
         <div class="">
           <div class="">
               <b>Cambios</b> {{ r.cambios }}
-                (<a href="https://siguealcongreso.org/monitoreo/iniciativas/{{ g.user['legislatura'].lower() }}/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
+                (<a href="https://siguealcongreso.org/iniciativas/{{ g.user['legislatura'].lower() }}/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
             <a href="https://congresoweb.congresojal.gob.mx/infolej/sistemaintegral/infolej/{{ r.documento }}" target="_blank" title="Leer el documento">🖹</a>
             {% if g.user and (r.usuario == g.user['usuario'] or g.user['rol'] in ('editor', 'admin')) %}
 	    <a href="edita/{{ r.numero }}" title="Editar">✏</a>

--- a/colabora/templates/lista_todas.html
+++ b/colabora/templates/lista_todas.html
@@ -69,7 +69,7 @@
         <div class="">
           <div class="">
               <b>Cambios</b> {{ r.cambios }}
-                (<a href="https://siguealcongreso.org/monitoreo/iniciativas/<legislatura>/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
+                (<a href="https://siguealcongreso.org/monitoreo/iniciativas/{{ g.user['legislatura'].lower() }}/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
             <a href="https://congresoweb.congresojal.gob.mx/infolej/sistemaintegral/infolej/{{ r.documento }}" target="_blank" title="Leer el documento">🖹</a>
             {% if g.user and (r.usuario == g.user['usuario'] or g.user['rol'] in ('editor', 'admin')) %}
 	    <a href="edita/{{ r.numero }}" title="Editar">✏</a>

--- a/colabora/templates/lista_todas.html
+++ b/colabora/templates/lista_todas.html
@@ -69,7 +69,7 @@
         <div class="">
           <div class="">
               <b>Cambios</b> {{ r.cambios }}
-                (<a href="https://siguealcongreso.org/monitoreo/iniciativas/lxiii/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
+                (<a href="https://siguealcongreso.org/monitoreo/iniciativas/<legislatura>/{{ r.numero }}/" title="Ver ficha">{{ r.numero }}</a>)
             <a href="https://congresoweb.congresojal.gob.mx/infolej/sistemaintegral/infolej/{{ r.documento }}" target="_blank" title="Leer el documento">🖹</a>
             {% if g.user and (r.usuario == g.user['usuario'] or g.user['rol'] in ('editor', 'admin')) %}
 	    <a href="edita/{{ r.numero }}" title="Editar">✏</a>


### PR DESCRIPTION
## Descripción:
Modificar enlaces de iniciativas.

## Cambios realizados:
Se cambiaron los enlaces de edita.html, lista_todas.html y lista.html

## Razón de la modificación:
Reparar bug para iniciativas más recientes.